### PR TITLE
Fix Masking Function

### DIFF
--- a/renderer/src/analytical.rs
+++ b/renderer/src/analytical.rs
@@ -12,7 +12,7 @@ impl Scene for AnalyticalScene {
 
     fn new() -> Self {
 
-        let em = 8.0;
+        let em = 5.0;
         let lights = vec![AnalyticalLight::spherical(F3::new(3.0, 2.0, 2.0), 1.0, F3::new(em, em, em))];
 
         Self {
@@ -28,7 +28,7 @@ impl Scene for AnalyticalScene {
     fn background(&self, ray: &Ray) -> F3 {
         // Taken from https://raytracing.github.io/books/RayTracingInOneWeekend.html, a source of great knowledge
         let t = 0.5 * (ray.direction.y + 1.0);
-        self.to_linear((1.0 - t) * F3::new(1.0, 1.0, 1.0) + t * F3::new(0.5, 0.7, 1.0)) * F3::new_x(0.1)
+        self.to_linear((1.0 - t) * F3::new(1.0, 1.0, 1.0) + t * F3::new(0.5, 0.7, 1.0)) * F3::new_x(0.8)
     }
 
 
@@ -53,8 +53,8 @@ impl Scene for AnalyticalScene {
             // state.material.clearcoat_gloss = 1.0;
             //state.material.roughness = 1.0;
 
-            state.material.rgb = F3::new_x(5.0);//PTF3::new(0.815, 0.418501512, 0.00180012);
-            state.material.roughness = 0.05;
+            state.material.rgb = F3::new_x(1.0);//PTF3::new(0.815, 0.418501512, 0.00180012);
+            state.material.roughness = 0.02;
             state.material.metallic = 1.0;
             //state.material.spec_trans = 1.0;
 

--- a/rust-pathtracer/src/tracer.rs
+++ b/rust-pathtracer/src/tracer.rs
@@ -286,8 +286,8 @@ impl Tracer {
     }
 
     fn smithganiso(&self, ndotv: &F, vdotx: &F, vdoty: &F, ax: &F, ay: &F) -> F {
-        let a = vdotx / ax;
-        let b = vdoty / ay;
+        let a = vdotx * ax;
+        let b = vdoty * ay;
         let c = ndotv;
         (2.0 * ndotv) / (ndotv + (a * a + b * b + c * c).sqrt())
     }


### PR DESCRIPTION
The smithganiso() function was incorrect. This PR fixes it. 

For light sources, you would need to check for lights in closest_hit() and use multiple importance sampling in render() whenever a ray hits a light source after a bounce. This along with the direct light sampling that's already being done should fix issues with lights in reflections.

Here is how the example scene looks like after the smithganiso() fix:

![image](https://user-images.githubusercontent.com/11459803/222907707-e131b056-5a89-4506-8da3-7d78dfda9cb2.png)